### PR TITLE
add `nodeBlockForRowAtIndexPath` support

### DIFF
--- a/Sources/DataSources/ASTableNode+Rx/RxASTableAnimatedDataSource.swift
+++ b/Sources/DataSources/ASTableNode+Rx/RxASTableAnimatedDataSource.swift
@@ -51,6 +51,31 @@ final class RxASTableAnimatedDataSource<S: AnimatableSectionModelType>: ASTableS
             sectionForSectionIndexTitle: sectionForSectionIndexTitle
         )
     }
+
+    public init(
+        animationConfiguration: RowAnimation = RowAnimation(),
+        animationType: @escaping AnimationType = { _, _, _ in .animated },
+        configureCellBlock: @escaping ConfigureCellBlock,
+        titleForHeaderInSection: @escaping  TitleForHeaderInSection = { _, _ in nil },
+        titleForFooterInSection: @escaping TitleForFooterInSection = { _, _ in nil },
+        canEditRowAtIndexPath: @escaping CanEditRowAtIndexPath = { _, _ in false },
+        canMoveRowAtIndexPath: @escaping CanMoveRowAtIndexPath = { _, _ in false },
+        sectionIndexTitles: @escaping SectionIndexTitles = { _ in nil },
+        sectionForSectionIndexTitle: @escaping SectionForSectionIndexTitle = { _, _, index in index }
+        ) {
+        self.animationConfiguration = animationConfiguration
+        self.animationType = animationType
+
+        super.init(
+            configureCellBlock: configureCellBlock,
+            titleForHeaderInSection: titleForHeaderInSection,
+            titleForFooterInSection: titleForFooterInSection,
+            canEditRowAtIndexPath: canEditRowAtIndexPath,
+            canMoveRowAtIndexPath: canMoveRowAtIndexPath,
+            sectionIndexTitles: sectionIndexTitles,
+            sectionForSectionIndexTitle: sectionForSectionIndexTitle
+        )
+    }
     #else
     public init(
         animationConfiguration: AnimationConfiguration = RowAnimation(),
@@ -66,6 +91,27 @@ final class RxASTableAnimatedDataSource<S: AnimatableSectionModelType>: ASTableS
     
     super.init(
         configureCell: configureCell,
+        titleForHeaderInSection: titleForHeaderInSection,
+        titleForFooterInSection: titleForFooterInSection,
+        canEditRowAtIndexPath: canEditRowAtIndexPath,
+        canMoveRowAtIndexPath: canMoveRowAtIndexPath
+    )
+    }
+
+    public init(
+        animationConfiguration: AnimationConfiguration = RowAnimation(),
+        animationType: @escaping AnimationType = { _, _, _ in .animated },
+        configureCellBlock: @escaping ConfigureCellBlock,
+        titleForHeaderInSection: @escaping  TitleForHeaderInSection = { _, _ in nil },
+        titleForFooterInSection: @escaping TitleForFooterInSection = { _, _ in nil },
+        canEditRowAtIndexPath: @escaping CanEditRowAtIndexPath = { _, _ in false },
+        canMoveRowAtIndexPath: @escaping CanMoveRowAtIndexPath = { _, _ in false }
+    ) {
+    self.animationConfiguration = animationConfiguration
+    self.animationType = animationType
+
+    super.init(
+        configureCellBlock: configureCellBlock,
         titleForHeaderInSection: titleForHeaderInSection,
         titleForFooterInSection: titleForFooterInSection,
         canEditRowAtIndexPath: canEditRowAtIndexPath,

--- a/Sources/DataSources/RxProxies/RxASTableDataSourceProxy.swift
+++ b/Sources/DataSources/RxProxies/RxASTableDataSourceProxy.swift
@@ -25,6 +25,10 @@ final class ASTableDataSourceNotSet: NSObject, ASTableDataSource {
     func tableNode(_ tableNode: ASTableNode, nodeForRowAt indexPath: IndexPath) -> ASCellNode {
         rxAbstractMethod(message: "DataSource not set")
     }
+
+    func tableNode(_ tableNode: ASTableNode, nodeBlockForRowAt indexPath: IndexPath) -> ASCellNodeBlock {
+        rxAbstractMethod(message: "DataSource not set")
+    }
 }
 
 extension ASTableNode: HasDataSource {
@@ -66,5 +70,12 @@ final class RxASTableDataSourceProxy: DelegateProxy<ASTableNode, ASTableDataSour
         let dataSource = _requiredMethodsDataSource ?? dataSourceNotSet
         
         return dataSource.tableNode!(tableNode, nodeForRowAt: indexPath)
+    }
+
+    /// Required datasource method implementation.
+    public func tableNode(_ tableNode: ASTableNode, nodeBlockForRowAt indexPath: IndexPath) -> ASCellNodeBlock {
+        let datasource = _requiredMethodsDataSource ?? dataSourceNotSet
+
+        return datasource.tableNode!(tableNode, nodeBlockForRowAt: indexPath)
     }
 }


### PR DESCRIPTION
fallback to `nodeForRowAtIndexPath` if nodeBlock is not defined by constructor.