### PR TITLE
invalid cartfile syntax

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 github "RxSwiftCommunity/RxDataSources"
 github "texturegroup/texture"
-github "pinterest/PINCache" ~> "3.0.1-beta.6"
+github "pinterest/PINCache" "3.0.1-beta.6"

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 github "RxSwiftCommunity/RxDataSources"
 github "texturegroup/texture"
-github "pinterest/PINCache" "3.0.1-beta.6"
+github "pinterest/PINCache" ~>  3.0.1


### PR DESCRIPTION
I'm sorry but I found `~> "brabra"` and `< "brabra"` syntax is not valid for Carthage. This problem reproduces if we remove `Cartfile.resolved` or execute `carthage update`.